### PR TITLE
feat: add pre-population task to Release module

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@
 import Config
 
 config :geolocator,
-  ecto_repos: [Geolocator.Repo]
+  ecto_repos: [Geolocator.Repo],
+  csv_stream_chunk_size: 1000
 
 # Set migrations timestamp type to :naive_datetime_usec (timestamp with milliseconds)
 config :geolocator, Geolocator.Repo, migration_timestamps: [type: :naive_datetime_usec]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,5 +3,9 @@ import Config
 # Do not print debug messages in production
 config :logger, level: :info
 
+config :geolocator,
+  # Fly.io instance is too small to handle 1000
+  csv_stream_chunk_size: 100
+
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/lib/geolocator/geolocations.ex
+++ b/lib/geolocator/geolocations.ex
@@ -10,7 +10,7 @@ defmodule Geolocator.Geolocations do
   alias Geolocator.Geolocations.ParsingReport
   alias Geolocator.Repo
 
-  @csv_stream_chunk_size 1_000
+  @csv_stream_chunk_size Application.compile_env(:geolocator, :csv_stream_chunk_size)
 
   @doc """
   Parses geolocations from the given CSV file and inserts them into the database in batches by #{@csv_stream_chunk_size}.

--- a/lib/geolocator/release.ex
+++ b/lib/geolocator/release.ex
@@ -4,6 +4,18 @@ defmodule Geolocator.Release do
   installed.
   """
   @app :geolocator
+  @prepopulate_url "https://raw.githubusercontent.com/viodotcom/backend-assignment-elixir/master/cloud_data_dump.csv"
+  @prepopulate_path "seeds.csv"
+
+  def prepopulate(url \\ @prepopulate_url, path \\ @prepopulate_path) do
+    load_app()
+
+    :ok = write_to_csv_file(path, url)
+    {:ok, report} = Geolocator.Geolocations.parse_geolocations_from_csv(path)
+    :ok = remove_file(path)
+
+    report
+  end
 
   def migrate do
     load_app()
@@ -24,5 +36,27 @@ defmodule Geolocator.Release do
 
   defp load_app do
     Application.load(@app)
+  end
+
+  defp write_to_csv_file(path, url) do
+    file = File.open!(path, [:write, :exclusive])
+    request = Finch.build(:get, url)
+
+    Finch.stream(request, Geolocator.Finch, nil, fn
+      {:status, _status}, _ ->
+        :ok
+
+      {:headers, _headers}, _ ->
+        :ok
+
+      {:data, data}, _ ->
+        IO.binwrite(file, data)
+    end)
+
+    File.close(file)
+  end
+
+  defp remove_file(path) do
+    File.rm(path)
   end
 end


### PR DESCRIPTION
## What?
- Adds pre-population task to Release module

## Why?
The added functionality simplifies the workflow by automating the downloading of the CSV file through stream-based operations, subsequently storing it as a temporary file. Following this step, existing mechanisms parse and insert the geolocation data into the appropriate databases. This newly implemented task can also be repurposed for scheduled cron operations in the future.

